### PR TITLE
Add several apis that were still missing from api.py and add an 'tado status' overview to the 'tado' tool.

### DIFF
--- a/libtado/__main__.py
+++ b/libtado/__main__.py
@@ -191,7 +191,7 @@ def status(tado):
     cur_hum =  st['sensorDataPoints']['humidity']['percentage']
 
     if st['link']['state'] != 'ONLINE':
-      setting = '-off-'
+      setting = '-x-' # Disconnected in tado-style
     elif st['setting']['power'] != 'ON':
       setting = st['setting']['power']
     else:


### PR DESCRIPTION
  Add get_device_usage, get_home_state, set_home_state, get_schedule_timetables,
  set_schedule, get_schedule_blocks, set_schedule_blocks, get_measuring_device,
  get_default_overlay, set_zone_name, get_away_configuration,
  set_open_window_detection, get_heating_circuits, get_incidents, get_installations,
  get_temperature_offset, set_temperature_offset apis.

* libtado/__main__.py
  Add 'status' command that gives an 'ls -l'-like overview of the current heating
  status.