### PR TITLE
fix(cli): Fix KeyError that occurs when libtado encounters a Hot Water zone

### DIFF
--- a/libtado/__main__.py
+++ b/libtado/__main__.py
@@ -272,7 +272,7 @@ def status(tado):
     st = tado.get_state(i['id'])
     if i['type'] == 'HEATING':
       show_heating(st)
-    elif i['type'] == "HOT_WATER":
+    elif i['type'] == 'HOT_WATER':
       show_hot_water(st)
 
 


### PR DESCRIPTION
This PR fixes an KeyError exception that occurs when libtado encounters a Hot Water zone that does not have a a current Temperature, Humidity or Heating setting.

Before change:
```
(libtado) ➜  libtado git:(master) ✗ tado status
Woonkamer       1       OFF -00:00   MANUAL  21.24C 48.4%
Slaapkamer 1    3       OFF -21:00   MANUAL  21.24C 50.1%
Overloop       10       OFF                  20.96C 53.4%
Slaapkamer 2    2       OFF -19:32   MANUAL  20.87C 45.1%
Zolder          9       OFF -22:00   MANUAL  22.52C 48.6%
Traceback (most recent call last):
  File "/Users/zian/.local/share/virtualenvs/libtado-TujzjsJ8/bin/tado", line 33, in <module>
    sys.exit(load_entry_point('libtado', 'console_scripts', 'tado')())
  File "/Users/zian/.local/share/virtualenvs/libtado-TujzjsJ8/lib/python3.8/site-packages/click/core.py", line 829, in __call__
    return self.main(*args, **kwargs)
  File "/Users/zian/.local/share/virtualenvs/libtado-TujzjsJ8/lib/python3.8/site-packages/click/core.py", line 782, in main
    rv = self.invoke(ctx)
  File "/Users/zian/.local/share/virtualenvs/libtado-TujzjsJ8/lib/python3.8/site-packages/click/core.py", line 1259, in invoke
    return _process_result(sub_ctx.command.invoke(sub_ctx))
  File "/Users/zian/.local/share/virtualenvs/libtado-TujzjsJ8/lib/python3.8/site-packages/click/core.py", line 1066, in invoke
    return ctx.invoke(self.callback, **ctx.params)
  File "/Users/zian/.local/share/virtualenvs/libtado-TujzjsJ8/lib/python3.8/site-packages/click/core.py", line 610, in invoke
    return callback(*args, **kwargs)
  File "/Users/zian/.local/share/virtualenvs/libtado-TujzjsJ8/lib/python3.8/site-packages/click/decorators.py", line 33, in new_func
    return f(get_current_context().obj, *args, **kwargs)
  File "/Users/zian/Develop/libtado/libtado/__main__.py", line 192, in status
    cur_temp = st['sensorDataPoints']['insideTemperature']['celsius']
KeyError: 'insideTemperature'
```

After change:
```
Woonkamer       1       OFF -00:00   MANUAL  21.15C 48.7%
Slaapkamer 1    3       OFF -21:00   MANUAL  21.04C 49.3%
Overloop       10       OFF                  20.85C 51.8%
Slaapkamer 2    2       OFF -19:32   MANUAL  20.59C 45.4%
Zolder          9       OFF -22:00   MANUAL  22.38C 48.4%
Warm water      0     55.0C -00:00                       
```