### PR TITLE
feat(cli): Add device VA02E on tado devices command

### DIFF
--- a/libtado/__main__.py
+++ b/libtado/__main__.py
@@ -73,6 +73,14 @@ def devices(tado):
       click.echo('Connection: %s (%s)' % (d['connectionState']['value'], d['connectionState']['timestamp']))
       click.echo('Mounted: %s (%s)' % (d['mountingState']['value'], d['mountingState']['timestamp']))
       click.echo('Battery State: %s' % d['batteryState'])
+    elif d['deviceType'] == 'VA02E':
+      # V2 smart radiator thermostat Basic
+      click.echo('Serial: %s' % d['serialNo'])
+      click.echo('Type: %s' % d['deviceType'])
+      click.echo('Firmware: %s' % d['currentFwVersion'])
+      click.echo('Connection: %s (%s)' % (d['connectionState']['value'], d['connectionState']['timestamp']))
+      click.echo('Mounted: %s (%s)' % (d['mountingState']['value'], d['mountingState']['timestamp']))
+      click.echo('Battery State: %s' % d['batteryState'])
     elif d['deviceType'] == 'RU02':
       # V2 smart wall theromstat
       click.echo('Serial: %s' % d['serialNo'])


### PR DESCRIPTION
Adding support for Tado Smart Radiator Thermostat Basic (the new low cost model without display).

This change was test, see issue https://github.com/germainlefebvre4/libtado/issues/124

