### PR TITLE
Add support for retrieving central heating flow temperature (OpenTherm)

### DIFF
--- a/libtado/__main__.py
+++ b/libtado/__main__.py
@@ -37,6 +37,15 @@ def capabilities(tado, zone):
   click.echo(tado.get_capabilities(zone))
 
 
+@main.command()
+@click.option('--authKey', '-a', required=True, type=int, help='Bridge auth code')
+@click.pass_obj
+def ch_flow_temp(tado, authkey):
+  """Display the current CH flow temperature (where applicable)."""
+  temp = tado.get_boiler_state(authkey)['boiler']['outputTemperature']
+  click.echo('Temperature: %s (%s)' % (temp['celsius'], temp['timestamp'],))
+
+
 @main.command(short_help='Display all devices.')
 @click.pass_obj
 def devices(tado):

--- a/libtado/api.py
+++ b/libtado/api.py
@@ -221,6 +221,47 @@ class Tado:
     self.refresh_token = response['refresh_token']
     self.access_headers['Authorization'] = 'Bearer ' + self.access_token
 
+  def get_boiler_state(self, authKey):
+    """
+    Parameters:
+      authKey (str|int): Auth code of bridge (from QR sticker; only V3/V3+
+        bridges supported)
+
+    Returns:
+      state (str): installation status of boiler receiver/thermostat
+      deviceWiredToBoiler (dict): type, serial number, protocol etc of
+        receiver/thermostat.
+      bridgeConnected (bool): brigge connection status
+      hotWaterZonePresent (bool): whether controller includes DHW
+      boiler (dict): output temperature (celcius) with timestamp
+
+    Example:
+      ```json
+      {
+        "state": "INSTALLATION_COMPLETED",
+        "deviceWiredToBoiler": {
+          "type": "BR02",
+          "serialNo": "SOME_SERIAL",
+          "thermInterfaceType": "OPENTHERM",
+          "connected": true,
+          "lastRequestTimestamp": "2023-11-18T16:22:01.788Z"
+        },
+        "bridgeConnected": true,
+        "hotWaterZonePresent": false,
+        "boiler": {
+          "outputTemperature": {
+            "celsius": 50.01,
+            "timestamp": "2023-11-18T16:29:35.785Z"
+          }
+        }
+      }
+      ```
+    """
+    devices = self.get_devices()
+    bridge_serial = [x for x in devices if x['deviceType'] == 'IB01'][0]['serialNo']
+    data = self._api_call('homeByBridge/%s/boilerWiringInstallationState?authKey=%s' % (bridge_serial, authKey))
+    return data
+
   def get_capabilities(self, zone):
     """
     Parameters:

--- a/tests/api/test_api.py
+++ b/tests/api/test_api.py
@@ -6,6 +6,7 @@ from libtado.api import Tado
 TADO_USERNAME = os.getenv("TADO_USERNAME", None)
 TADO_PASSWORD = os.getenv("TADO_PASSWORD", None)
 TADO_CLIENT_SECRET = os.getenv("TADO_CLIENT_SECRET", None)
+TADO_BRIDGE_AUTHKEY = os.getenv("TADO_BRIDGE_AUTHKEY", None)
 
 tado = Tado(TADO_USERNAME, TADO_PASSWORD, TADO_CLIENT_SECRET)
 
@@ -23,6 +24,20 @@ class TestApi:
         assert all(name in response[0]["devices"][0] for name in KEYS)
 
         assert response[0]["id"] == 1
+
+    def test_get_boiler_state(self):
+        response = tado.get_boiler_state(TADO_BRIDGE_AUTHKEY)
+
+        assert isinstance(response, dict)
+
+        KEYS = ["state", "deviceWiredToBoiler", "hotWaterZonePresent", "boiler"]
+        assert all(name in response for name in KEYS)
+        assert isinstance(response["state"], str)
+        assert isinstance(response["hotWaterZonePresent"], bool)
+        KEYS = ["type", "serialNo", "thermInterfaceType", "connected", "lastRequestTimestamp"]
+        assert all(name in response["deviceWiredToBoiler"] for name in KEYS)
+        KEYS = ["celsius", "timestamp"]
+        assert all(name in response["boiler"]["outputTemperature"] for name in KEYS)
 
     def test_get_capabilities(self):
         ZONE_ID = tado.get_zones()[0]["id"]
@@ -44,39 +59,43 @@ class TestApi:
         assert isinstance(response, list)
         assert len(response) > 0
 
-        DEVICES_BU = [x for x in response if x["deviceType"] == "BU01"]
-        KEYS = ["deviceType", "serialNo", "shortSerialNo", "currentFwVersion", "connectionState", "characteristics", "isDriverConfigured"]
-        assert all(name in DEVICES_BU[0] for name in KEYS)
-        KEYS = ["value", "timestamp"]
-        assert all(name in DEVICES_BU[0]["connectionState"] for name in KEYS)
-        KEYS = ["capabilities"]
-        assert all(name in DEVICES_BU[0]["characteristics"] for name in KEYS)
+        DEVICES_BU = [x for x in response if x["deviceType"] in ("BU01", "BR02")]
+        if DEVICES_BU:
+            KEYS = ["deviceType", "serialNo", "shortSerialNo", "currentFwVersion", "connectionState", "characteristics", "isDriverConfigured"]
+            assert all(name in DEVICES_BU[0] for name in KEYS)
+            KEYS = ["value", "timestamp"]
+            assert all(name in DEVICES_BU[0]["connectionState"] for name in KEYS)
+            KEYS = ["capabilities"]
+            assert all(name in DEVICES_BU[0]["characteristics"] for name in KEYS)
 
         DEVICES_GW = [x for x in response if x["deviceType"] == "GW03"]
-        KEYS = ["deviceType", "serialNo", "shortSerialNo", "currentFwVersion", "connectionState", "characteristics", "inPairingMode"]
-        assert all(name in DEVICES_GW[0] for name in KEYS)
-        KEYS = ["value", "timestamp"]
-        assert all(name in DEVICES_GW[0]["connectionState"] for name in KEYS)
-        KEYS = ["capabilities"]
-        assert all(name in DEVICES_GW[0]["characteristics"] for name in KEYS)
+        if DEVICES_GW:
+            KEYS = ["deviceType", "serialNo", "shortSerialNo", "currentFwVersion", "connectionState", "characteristics", "inPairingMode"]
+            assert all(name in DEVICES_GW[0] for name in KEYS)
+            KEYS = ["value", "timestamp"]
+            assert all(name in DEVICES_GW[0]["connectionState"] for name in KEYS)
+            KEYS = ["capabilities"]
+            assert all(name in DEVICES_GW[0]["characteristics"] for name in KEYS)
 
         DEVICES_RU = [x for x in response if x["deviceType"] == "RU01"]
-        KEYS = ["deviceType", "serialNo", "shortSerialNo", "currentFwVersion", "connectionState", "characteristics", "batteryState"]
-        assert all(name in DEVICES_RU[0] for name in KEYS)
-        KEYS = ["value", "timestamp"]
-        assert all(name in DEVICES_RU[0]["connectionState"] for name in KEYS)
-        KEYS = ["capabilities"]
-        assert all(name in DEVICES_RU[0]["characteristics"] for name in KEYS)
+        if DEVICES_RU:
+            KEYS = ["deviceType", "serialNo", "shortSerialNo", "currentFwVersion", "connectionState", "characteristics", "batteryState"]
+            assert all(name in DEVICES_RU[0] for name in KEYS)
+            KEYS = ["value", "timestamp"]
+            assert all(name in DEVICES_RU[0]["connectionState"] for name in KEYS)
+            KEYS = ["capabilities"]
+            assert all(name in DEVICES_RU[0]["characteristics"] for name in KEYS)
 
         DEVICES_VA = [x for x in response if x["deviceType"] == "VA01"]
-        KEYS = ["deviceType", "serialNo", "shortSerialNo", "currentFwVersion", "connectionState", "characteristics", "mountingState", "batteryState"]
-        assert all(name in DEVICES_VA[0] for name in KEYS)
-        KEYS = ["value", "timestamp"]
-        assert all(name in DEVICES_VA[0]["connectionState"] for name in KEYS)
-        KEYS = ["capabilities"]
-        assert all(name in DEVICES_VA[0]["characteristics"] for name in KEYS)
-        KEYS = ["value", "timestamp"]
-        assert all(name in DEVICES_VA[0]["mountingState"] for name in KEYS)
+        if DEVICES_VA:
+            KEYS = ["deviceType", "serialNo", "shortSerialNo", "currentFwVersion", "connectionState", "characteristics", "mountingState", "batteryState"]
+            assert all(name in DEVICES_VA[0] for name in KEYS)
+            KEYS = ["value", "timestamp"]
+            assert all(name in DEVICES_VA[0]["connectionState"] for name in KEYS)
+            KEYS = ["capabilities"]
+            assert all(name in DEVICES_VA[0]["characteristics"] for name in KEYS)
+            KEYS = ["value", "timestamp"]
+            assert all(name in DEVICES_VA[0]["mountingState"] for name in KEYS)
 
     def test_get_early_start(self):
         ZONE_ID = tado.get_zones()[0]["id"]


### PR DESCRIPTION
Since [October 2022](https://community.tado.com/en-gb/discussion/8611/release-opentherm-max-flow-temperature-setting/p1), API endpoints have existed to set the maximum flow temperature and get the last recorded flow temperature on OpenTherm installations (at the least).

This PR adds support for reading current flow temperature (API and CLI).  I haven't added a setter, but it [looks like it would not be difficult](https://community.tado.com/en-gb/discussion/comment/67688/#Comment_67688).

A test is included, and I also updated `test_devices` to cope when not all the devices checked are available in this instance.