### PR TITLE
feat(auth)!: Implemented new OAuth device code grant flow

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,52 +26,64 @@ git clone https://github.com/germainlefebvre4/libtado.git
 
 Please check out [https://libtado.readthedocs.io](https://libtado.readthedocs.io) for more documentation.
 
-## Preparation
-
-Retrieve the `CLIENT_SECRET` before running the script otherwise you will get a `401 Unauthorized Access`.
-
-The latest `CLIENT_SECRET` can be found at [https://my.tado.com/webapp/env.js](https://my.tado.com/webapp/env.js).  It will look something like this:
-
-```js
-var TD = {
-    config: {
-        version: 'v588',
-        oauth: {
-          clientSecret: 'wZaRN7rpjn3FoNyF5IFuxg9uMzYJcvOoQ8QWiIqS3hfk6gLhVlG57j5YNoZL2Rtc'
-        }
-    }
-};
-```
-
-An alternative way to get your `CLIENT_SECRET` is to enable the Developper Mode when logging in and catch the Headers. You will find the form data like this :
-
-```yaml
-client_id: tado-web-app
-client_secret: fndskjnjzkefjNFRNkfKJRNFKRENkjnrek
-grant_type: password
-password: MyBeautifulPassword
-scope: home.user
-username: email@example.com
-```
-
-Then you just have to get the value in the attribute `client_secret`. You will need it to connect to your account through Tado APIs. The `client_secret` never dies so you can base your script on it.
-
 ## Usage
 
 Download the repository. You can work inside it. Beware that the examples assume that they can access the file `./libtado/api.py`.
 
-Now you can call it in your Pyhton script!
+Define a location and filename that will hold the credentials (refresh token) of your Tado login.
+
+It is recommended to use a directory that only your application has access to, as the credentials file
+holds sensitive information!
+
+Now you can call it in your Python script!
 
 ```python
 import libtado.api
+import webbrowser   # only needed for direct web browser access
 
-t = api.Tado('my@email.com', 'myPassword', 'client_secret')
+# TODO check
+t = api.Tado(token_file='/tmp/.libtado_refresh_token.json')
+# OR: t = api.Tado(saved_refresh_token='my_refresh_token')
+
+status = t.get_device_activation_status()
+
+if status == "PENDING":
+    url = t.get_device_verification_url()
+
+    # to auto-open the browser (on a desktop device), un-comment the following line:
+    # webbrowser.open_new_tab(url)
+
+    t.device_activation()
+
+    status = t.get_device_activation_status()
+
+if status == "COMPLETED":
+    print("Login successful")
+else:
+    print(f"Login status is {status}")
+
 
 print(t.get_me())
 print(t.get_home())
 print(t.get_zones())
 print(t.get_state(1))
 ```
+
+The first time, the script will tell you to login to your Tado account. 
+
+It will show an output like:
+
+```
+Please visit the following URL in your Web browser to log in to your Tado account: https://login.tado.com/oauth2/device?user_code=1234567
+Waiting for you to complete logging in. You have until yyyy-MM-dd hh:mm:ss
+.
+```
+
+Complete your login before the time indicated.
+
+Afterwards, the script should print the information from your Tado home.
+
+If using the `token_file`, the next time you should not have to sign in.
 
 ## Examples
 

--- a/check.py
+++ b/check.py
@@ -4,12 +4,23 @@ from libtado.api import Tado
 from dotenv import load_dotenv
 load_dotenv()
 
+TADO_REFRESH_TOKEN = os.environ["TADO_REFRESH_TOKEN"]
+TADO_CREDENTIALS_FILE = os.environ["TADO_CREDENTIALS_FILE"]
 
-TADO_USERNAME = os.environ["TADO_USERNAME"]
-TADO_PASSWORD = os.environ["TADO_PASSWORD"]
-TADO_CLIENT_SECRET = os.environ["TADO_CLIENT_SECRET"]
+tado = Tado(TADO_REFRESH_TOKEN, TADO_CREDENTIALS_FILE)
 
-tado = Tado(TADO_USERNAME, TADO_PASSWORD, TADO_CLIENT_SECRET)
+status = tado.get_device_activation_status()
+if status == "PENDING":
+    url = tado.get_device_verification_url()
+
+    tado.device_activation()
+
+    status = tado.get_device_activation_status()
+
+if status == "COMPLETED":
+    print("Login successful")
+else:
+    print(f"Login status is {status}")
 
 # print(tado.get_me())
 # print(tado.get_home())

--- a/docs/api/usage.md
+++ b/docs/api/usage.md
@@ -5,7 +5,7 @@ Usage:
 ``` { .python .select .copy }
 import libtado.api
 
-api = tado.api('Username', 'Password')
+api = tado.api(token_file_path='/path/to/a/secure/folder/tado-credentials.json')
 ```
 
 For API Reference see [API Reference](../api/reference.md)

--- a/docs/cli/configuration.md
+++ b/docs/cli/configuration.md
@@ -8,9 +8,9 @@ There is no configuration file. No need.
 
 The following environment variables are supported:
 
-* `TADO_USERNAME` - Tado username
-* `TADO_PASSWORD` - Tado password
-* `TADO_CLIENT_SECRET` - Tado client secret
+* `TADO_CREDENTIALS_FILE` - Path to a file which holds your Tado credentials. Be careful: do not share this file with others.
+* `TADO_REFRESH_TOKEN` - Tado refresh token, from previous login. Valid for one-time use only.
+
 
 Environment variables can be set up in multiples ways:
 

--- a/docs/cli/usage.md
+++ b/docs/cli/usage.md
@@ -13,16 +13,21 @@ Usage: tado [OPTIONS] COMMAND [ARGS]...
 
     This script provides a command line client for the Tado API.
 
-    You can use the environment variables TADO_USERNAME and TADO_PASSWORD
-    instead of the command line options.
+    You can use the environment variables TADO_REFRESH_TOKEN and
+    TADO_CREDENTIALS_FILE instead of the command line options.
+
+    The first time you will have to login using a browser. The command
+    will show an URL to perform the login.
+
+    If using the credentials-file option or variable, the login will
+    be stored so you don't have to do this next time.
 
     Call 'tado COMMAND --help' to see available options for subcommands.
 
 Options:
-    -u, --username TEXT       Tado username  [required]
-    -p, --password TEXT       Tado password  [required]
-    -c, --client-secret TEXT  Tado password  [optional]
-    -h, --help                Show this message and exit.
+    -f, --credentials-file TEXT   Full path to a file in which the Tado credentials will be stored and read from [optional]
+    -t, --refresh-token TEXT      A Tado refresh token, retrieved from prior authentication with Tado [optional]
+    -h, --help                    Show this message and exit.
 
 Commands:
     capabilities        Display the capabilities of a zone.

--- a/docs/faq.md
+++ b/docs/faq.md
@@ -1,28 +1,2 @@
 # FAQ
 
-## How to retrieve the client secret
-
-### Option #1: Do nothing
-
-The library wil automatically retrieve the client secret on following the steps at *Options #2*.
-
-### Option #2: From the application `env.js`
-
-Retrieve the `CLIENT_SECRET` before running the script otherwise you will get a `401 Unauthorized Access`. The latest `CLIENT_SECRET` can be found at \[<https://my.tado.com/webapp/env.js>\](<https://my.tado.com/webapp/env.js>). It will look something like this:
-
-### Option #3: From the developer mode
-
-An alternative way to get your `CLIENT_SECRET` is to enable the Developper Mode when logging in and catch the Headers. You will find the form data like this:
-
-```json
-{
-    client_id: tado-web-app
-    client_secret: fndskjnjzkefjNFRNkfKJRNFKRENkjnrek
-    grant_type: password
-    password: MyBeautifulPassword
-    scope: home.user
-    username: email@example.com
-}
-```
-
-Then you just have to get the value in the attribute `client_secret`. You will need it to connect to your account through Tado APIs. The `client_secret` never dies so you can base your script on it.

--- a/docs/getting-started/usage.md
+++ b/docs/getting-started/usage.md
@@ -3,15 +3,33 @@
 After you installed libtado you can easily test it by using the included [`cli`](../cli/usage.md) like this:
 
 ``` { shell .copy }
-tado --username USERNAME --password PASSWORD whoami
+tado --credentials-file /path/to/a/secure/folder/tado-credentials.json whoami
 ```
 
 To use the library in your own code you can start with this:
 
 ``` python
 import libtado.api
-t = tado.api('Username', 'Password')
-print(t.get_me())
+import webbrowser   # only needed for direct web browser access
+
+t = tado.api(token_file_path='/path/to/a/secure/folder/tado-credentials.json')
+
+status = t.get_device_activation_status()
+
+if status == "PENDING":
+    url = t.get_device_verification_url()
+
+    # to auto-open the browser (on a desktop device), un-comment the following line:
+    # webbrowser.open_new_tab(url)
+
+    t.device_activation()
+
+    status = t.get_device_activation_status()
+
+if status == "COMPLETED":
+    print("Login successful")
+else:
+    print(f"Login status is {status}")
 ```
 
 Check out `all available API methods <api>` to learn what you can to with libtado.

--- a/example.py
+++ b/example.py
@@ -1,6 +1,25 @@
 from libtado.api import Tado
+import webbrowser   # only needed for direct web browser access
 
-t = Tado('my@email.com', 'myPassword', 'client_secret')
+t = Tado(token_file_path='/tmp/.libtado-refresh-token')
+# OR: t = Tado(saved_refresh_token='my-refresh-token')
+
+status = t.get_device_activation_status()
+
+if status == "PENDING":
+    url = t.get_device_verification_url()
+
+    # to auto-open the browser (on a desktop device), un-comment the following line:
+    # webbrowser.open_new_tab(url)
+
+    t.device_activation()
+
+    status = t.get_device_activation_status()
+
+if status == "COMPLETED":
+    print("Login successful")
+else:
+    print(f"Login status is {status}")
 
 print(t.get_me())
 print(t.get_home())

--- a/libtado/__main__.py
+++ b/libtado/__main__.py
@@ -10,23 +10,29 @@ import libtado.api
 CONTEXT_SETTINGS = dict(help_option_names=['-h', '--help'])
 
 @click.group(context_settings=CONTEXT_SETTINGS)
-@click.option('--username', '-u', required=True, envvar='TADO_USERNAME', help='Tado username')
-@click.option('--password', '-p', required=True, envvar='TADO_PASSWORD', help='Tado password')
-@click.option('--client-secret', '-c', required=True, envvar='TADO_CLIENT_SECRET', help='Tado client secret')
+@click.option('--refresh-token', '-t', required=True, envvar='TADO_REFRESH_TOKEN', help='A Tado refresh token, retrieved from prior authentication with Tado')
+@click.option('--credentials-file', '-f', required=True, envvar='TADO_CREDENTIALS_FILE', help='Full path to a file in which the Tado credentials will be stored and read from')
 @click.pass_context
-def main(ctx, username, password, client_secret):
+def main(ctx, refresh_token, saved_refresh_token_file):
   """
   Example
   =======
   This script provides a command line client for the Tado API.
 
-  You can use the environment variables TADO_USERNAME, TADO_PASSWORD and
-  TADO_CLIENT_SECRET instead of the command line options.
+  You can use the environment variables TADO_REFRESH_TOKEN and
+  TADO_CREDENTIALS_FILE instead of the command line options.
+
+  The first time you will have to login using a browser. The command
+  will show an URL to perform the login.
+
+  If using the credentials-file option or variable, the login will
+  be stored so you don't have to do this next time.
 
   Call 'tado COMMAND --help' to see available options for subcommands.
   """
 
-  ctx.obj = libtado.api.Tado(username, password, client_secret)
+  ctx.obj = libtado.api.Tado(refresh_token, saved_refresh_token_file)
+  ctx.obj.device_activation()
 
 
 @main.command()

--- a/tests/api/test_api.py
+++ b/tests/api/test_api.py
@@ -5,11 +5,11 @@ from libtado.api import Tado
 from tests.api import utils
 import pytest
 
-TADO_USERNAME = os.getenv("TADO_USERNAME", None)
-TADO_PASSWORD = os.getenv("TADO_PASSWORD", None)
-TADO_CLIENT_SECRET = os.getenv("TADO_CLIENT_SECRET", None)
+TADO_REFRESH_TOKEN = os.environ["TADO_REFRESH_TOKEN"]
+TADO_CREDENTIALS_FILE = os.environ["TADO_CREDENTIALS_FILE"]
+tado = Tado(TADO_REFRESH_TOKEN, TADO_CREDENTIALS_FILE)
 
-tado = Tado(TADO_USERNAME, TADO_PASSWORD, TADO_CLIENT_SECRET)
+tado.device_activation()
 
 
 class TestApi:

--- a/tests/api/test_jsonschema.py
+++ b/tests/api/test_jsonschema.py
@@ -4,11 +4,11 @@
 # from jsonschema import validate
 # from tests.api import utils
 
-# TADO_USERNAME = os.getenv("TADO_USERNAME", None)
-# TADO_PASSWORD = os.getenv("TADO_PASSWORD", None)
-# TADO_CLIENT_SECRET = os.getenv("TADO_CLIENT_SECRET", None)
 
-# tado = Tado(TADO_USERNAME, TADO_PASSWORD, TADO_CLIENT_SECRET)
+# TADO_REFRESH_TOKEN = os.environ["TADO_REFRESH_TOKEN"]
+# TADO_CREDENTIALS_FILE = os.environ["TADO_CREDENTIALS_FILE"]
+# tado = Tado(TADO_REFRESH_TOKEN, TADO_CREDENTIALS_FILE)
+# tado.device_activation()
 
 
 # def test_jsonschema_get_air_comfort_geoloc_is_valid():

--- a/tests/api/utils.py
+++ b/tests/api/utils.py
@@ -3,11 +3,10 @@ from datetime import date
 from dateutil.relativedelta import relativedelta
 from libtado.api import Tado
 
-TADO_USERNAME = os.getenv("TADO_USERNAME", None)
-TADO_PASSWORD = os.getenv("TADO_PASSWORD", None)
-TADO_CLIENT_SECRET = os.getenv("TADO_CLIENT_SECRET", None)
-
-tado = Tado(TADO_USERNAME, TADO_PASSWORD, TADO_CLIENT_SECRET)
+TADO_REFRESH_TOKEN = os.environ["TADO_REFRESH_TOKEN"]
+TADO_CREDENTIALS_FILE = os.environ["TADO_CREDENTIALS_FILE"]
+tado = Tado(TADO_REFRESH_TOKEN, TADO_CREDENTIALS_FILE)
+tado.device_activation()
 
 
 class TestApi:


### PR DESCRIPTION
This commit introduces the new device code grant flow introduced by Tado and required as of 2025-03-21.

The changes are highly based on python-tado, release 0.18.9 See: https://github.com/wmalgadey/PyTado/commits/0.18.9/

For more information about the change by Tado,
See: https://support.tado.com/en/articles/8565472-how-do-i-authenticate-to-access-the-rest-api