### PR TITLE
Formerly `set_schedule_block_by_day_type()` is improved and replaces former `set_schedule_blocks()`

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,12 +47,11 @@ holds sensitive information!
 Now you can call it in your Python script!
 
 ```python
-import libtado.api
+from libtado.api import Tado
 import webbrowser   # only needed for direct web browser access
 
-# TODO check
-t = api.Tado(token_file='/tmp/.libtado_refresh_token.json')
-# OR: t = api.Tado(saved_refresh_token='my_refresh_token')
+t = Tado(token_file_path='/tmp/.libtado-refresh-token')
+# OR: t = Tado(saved_refresh_token='my-refresh-token')
 
 status = t.get_device_activation_status()
 
@@ -60,7 +59,7 @@ if status == "PENDING":
     url = t.get_device_verification_url()
 
     # to auto-open the browser (on a desktop device), un-comment the following line:
-    # webbrowser.open_new_tab(url)
+    webbrowser.open_new_tab(url)
 
     t.device_activation()
 
@@ -70,7 +69,6 @@ if status == "COMPLETED":
     print("Login successful")
 else:
     print(f"Login status is {status}")
-
 
 print(t.get_me())
 print(t.get_home())


### PR DESCRIPTION
The function now reads the `day_type` from the `blocks` and handles the API calls on a `day_type` basis. This was not the case, and thus problematic in some cases: https://github.com/germainlefebvre4/libtado/issues/201#issuecomment-3167344521.

The code groups all `day_type`s together, so the `block` argument doesn't have to be organized.

I added a check mechanism, so invalid `day_type`s are ignored, to avoid `443` responses.

Since the `day_type` is retrieved from the `blocks`, it's no longer an argument, which means that the documentation (https://libtado.readthedocs.io/en/latest/api/reference/?h=set_s#libtado.api.Tado.set_schedule_block_by_day_type) should be amended accordingly.

The current function now does what former `set_schedule_blocks()` should do, but was unable (see https://github.com/germainlefebvre4/libtado/issues/201, which was not really resolved by PR https://github.com/germainlefebvre4/libtado/pull/224).

If this PR is merged, it's important to change the documentation here (https://libtado.readthedocs.io/en/latest/api/reference/#libtado.api.Tado.set_schedule_blocks) and here (https://libtado.readthedocs.io/en/latest/api/reference/#libtado.api.Tado.set_schedule_block_by_day_type). Actually, the documentation is already outdated, I'm afraid.

[The tests](https://github.com/germainlefebvre4/libtado/blob/18dc32131e1bca8dee1f02a45ff00e3be6debb49/docs/contributing.md#test-your-changes) failed, but not because of my additions, I would think:
```
(venv-libtado) PS C:\Git\libtado> poetry run pytest -sv tests/
=================================================================== test session starts ===================================================================
platform win32 -- Python 3.12.4, pytest-8.4.1, pluggy-1.6.0 -- C:\Git\tado-schedules\venv-libtado\Scripts\python.exe
cachedir: .pytest_cache
rootdir: C:\Git\libtado
configfile: pytest.ini
plugins: anyio-4.10.0
collecting ... Please visit the following URL in your Web browser to log in to your Tado account: https://login.tado.com/oauth2/device?user_code=TPR87M
Waiting for you to complete logging in. You have until 2025-08-08 21:45:17
........
collected 18 items

tests/api/test_api.py::TestApi::test_get_zones FAILED
tests/api/test_api.py::TestApi::test_get_capabilities PASSED
tests/api/test_api.py::TestApi::test_get_devices PASSED
tests/api/test_api.py::TestApi::test_get_early_start PASSED
tests/api/test_api.py::TestApi::test_get_home PASSED
tests/api/test_api.py::TestApi::test_get_invitations PASSED
tests/api/test_api.py::TestApi::test_get_me PASSED
tests/api/test_api.py::TestApi::test_get_mobile_devices PASSED
tests/api/test_api.py::TestApi::test_get_schedule PASSED
tests/api/test_api.py::TestApi::test_get_state PASSED
tests/api/test_api.py::TestApi::test_get_users PASSED
tests/api/test_api.py::TestApi::test_get_weather PASSED
tests/api/test_api.py::TestApi::test_get_report PASSED
tests/api/test_api.py::TestApi::test_get_air_comfort PASSED
tests/api/test_api.py::TestApi::test_get_air_comfort_geoloc PASSED
tests/api/test_api.py::TestApi::test_set_cost_simulation FAILED
tests/api/test_api.py::TestApi::test_get_consumption_overview PASSED
tests/api/test_api.py::TestApi::test_get_energy_settings FAILED

======================================================================== FAILURES =========================================================================
_________________________________________________________________ TestApi.test_get_zones __________________________________________________________________

self = <test_api.TestApi object at 0x00000241A53CD580>

    def test_get_zones(self):
        response = utils.TestApi.get_zones()

        assert isinstance(response, list)
        assert len(response) > 0
>       assert response[0]["id"] == 1
E       assert 2 == 1

tests\api\test_api.py:15: AssertionError
____________________________________________________________ TestApi.test_set_cost_simulation _____________________________________________________________

self = <test_api.TestApi object at 0x00000241A5F5C140>

    def test_set_cost_simulation(self):
        monthYear = date.today().strftime("%Y-%m") # 2023-09
        country = "FRA"
        response = tado.get_consumption_overview(monthYear=monthYear, country=country)
>       consumption_sum = sum([x["consumption"] for x in response["monthlyAggregation"]["requestedMonth"]["consumptionPerDate"]])
                              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
E       TypeError: 'NoneType' object is not iterable

tests\api\test_api.py:121: TypeError
____________________________________________________________ TestApi.test_get_energy_settings _____________________________________________________________

self = <test_api.TestApi object at 0x00000241A5F5C440>

    def test_get_energy_settings(self):
>       response = tado.get_energy_settings()
                   ^^^^^^^^^^^^^^^^^^^^^^^^^^

tests\api\test_api.py:160:
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _
libtado\api.py:2917: in get_energy_settings
    data = self._api_energy_insights_call('homes/%i/settings?ngsw-bypass=%s' % (self.id, ngsw_bypass))
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
libtado\api.py:357: in _api_energy_insights_call
    return call_get(url).json()
           ^^^^^^^^^^^^^
libtado\api.py:343: in call_get
    r.raise_for_status()
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _

self = <Response [404]>

    def raise_for_status(self):
        """Raises :class:`HTTPError`, if one occurred."""

        http_error_msg = ""
        if isinstance(self.reason, bytes):
            # We attempt to decode utf-8 first because some servers
            # choose to localize their reason strings. If the string
            # isn't utf-8, we fall back to iso-8859-1 for all other
            # encodings. (See PR #3538)
            try:
                reason = self.reason.decode("utf-8")
            except UnicodeDecodeError:
                reason = self.reason.decode("iso-8859-1")
        else:
            reason = self.reason

        if 400 <= self.status_code < 500:
            http_error_msg = (
                f"{self.status_code} Client Error: {reason} for url: {self.url}"
            )

        elif 500 <= self.status_code < 600:
            http_error_msg = (
                f"{self.status_code} Server Error: {reason} for url: {self.url}"
            )

        if http_error_msg:
>           raise HTTPError(http_error_msg, response=self)
E           requests.exceptions.HTTPError: 404 Client Error: Not Found for url: https://energy-insights.tado.com/api/homes/1375166/settings?ngsw-bypass=True

..\tado-schedules\venv-libtado\Lib\site-packages\requests\models.py:1026: HTTPError
==================================================================== warnings summary =====================================================================
..\tado-schedules\venv-libtado\Lib\site-packages\_pytest\config\__init__.py:1474
  C:\Git\tado-schedules\venv-libtado\Lib\site-packages\_pytest\config\__init__.py:1474: PytestConfigWarning: Unknown config option: env_files

    self._warn_or_fail_if_strict(f"Unknown config option: {key}\n")

..\tado-schedules\venv-libtado\Lib\site-packages\_pytest\config\__init__.py:1474
  C:\Git\tado-schedules\venv-libtado\Lib\site-packages\_pytest\config\__init__.py:1474: PytestConfigWarning: Unknown config option: env_override_existing_values

    self._warn_or_fail_if_strict(f"Unknown config option: {key}\n")

-- Docs: https://docs.pytest.org/en/stable/how-to/capture-warnings.html
================================================================= short test summary info =================================================================
FAILED tests/api/test_api.py::TestApi::test_get_zones - assert 2 == 1
FAILED tests/api/test_api.py::TestApi::test_set_cost_simulation - TypeError: 'NoneType' object is not iterable
FAILED tests/api/test_api.py::TestApi::test_get_energy_settings - requests.exceptions.HTTPError: 404 Client Error: Not Found for url: https://energy-insights.tado.com/api/homes/1375166/settings?ngsw-bypass=True
======================================================== 3 failed, 15 passed, 2 warnings in 52.72s ========================================================
(venv-libtado) PS C:\Git\libtado> poetry run python generate_json_schemas.py
Please visit the following URL in your Web browser to log in to your Tado account: https://login.tado.com/oauth2/device?user_code=L5CW4F
Waiting for you to complete logging in. You have until 2025-08-08 21:46:14

Calling get_air_comfort
Generating schema for get_air_comfort
Traceback (most recent call last):
  File "C:\Git\libtado\generate_json_schemas.py", line 27, in <module>
    schema = generate_jsonschema_file(f"{method}", res)
             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "C:\Git\libtado\generate_json_schemas.py", line 11, in generate_jsonschema_file
    from genson import SchemaBuilder
ModuleNotFoundError: No module named 'genson'
```
