### PR TITLE
fix(docs): Corrected api docs for function `get_rate_limit_info`

### DIFF
--- a/docs/faq.md
+++ b/docs/faq.md
@@ -16,3 +16,18 @@ But the consequences of that change are that library handles differently the aut
     Now, you have to use the `TADO_CREDENTIALS_FILE` or `TADO_REFRESH` variables to authenticate.
 
 You can find more documentation on how to authenticate in the [**CLI Configuration**](./cli/configuration.md) section.
+
+## Every operation fails with HTTP Error 429. Why is this happening?
+
+If this happens, you've probably reached the API
+[rate limit](https://help.tado.com/en/articles/12165739-limitation-for-rest-api-usage).
+This is something which has been introduced by Tado in September 2025.
+
+Libtado uses the REST API to get information from, and to control your Tado system.
+
+If this happens, you'll have to wait for the rate limit to be reset.
+This can take up to **24 hours**.
+
+The limit will be higher, but not unlimited, if you have the Auto Assist / AI Assist subscription.
+
+You can use the function [`get_rate_limit_info`](./api/reference.md#libtado.api.Tado.get_rate_limit_info) to see how many API calls you still have left.

--- a/libtado/api.py
+++ b/libtado/api.py
@@ -3238,7 +3238,24 @@ class Tado:
 
   def get_rate_limit_info(self) -> RateLimitInfo:
     """
-    Returns Your account's usage limit and remaining API calls for the Tado API.
-    :return: Object containing how many API calls are allowed to the Tado API, and how many are left in current window.
+    Get your account's usage limit and remaining API calls for the Tado API.
+
+    As of September 2025, Tado has started introducing
+    [rate limits](https://help.tado.com/en/articles/12165739-limitation-for-rest-api-usage) on their REST API.
+
+    The REST API is a component which libtado uses to retrieve data from, and to control your Tado system.
+
+    The rate limit determines how often you can request data from Tado's servers.
+    If you have fully reached the API limit, libtado will show an error for every operation: 429 Too Many Requests.
+
+    If this happens, you'll have to wait until the Rate Limit has been reset. This can take up to **24 hours**.
+
+    The limit will be higher, but not unlimited, if you have the Auto Assist / AI Assist subscription.
+
+    Returns:
+      granted_calls (int): How many API calls can make within a period.
+      granted_calls_period_in_seconds (int): The duration of the period (in seconds) in which your API usage is measured.
+      remaining_calls (int): How many API calls you have left in the current period.
+      ratelimit_resets_at_utc (datetime): Optionally: When the period for remaining API calls ends (and the rate limit will be reset).
     """
     return self.ratelimit_info


### PR DESCRIPTION
Fixed API reference documentation for function `get_rate_limit_info` to show correct return type and information what it does.

Added entry to the FAQ for when getting HTTP 429 errors if the rate limit has been fully reached.

<img width="1000" height="641" alt="Scherm­afbeelding 2025-12-29 om 14 11 12" src="https://github.com/user-attachments/assets/0fead8b0-9120-400b-9876-4c575cbcdcd5" />

<img width="729" height="337" alt="Scherm­afbeelding 2025-12-29 om 14 11 28" src="https://github.com/user-attachments/assets/27f73003-8136-4f47-8084-f8cbbf06e5a4" />
