### PR TITLE
feat: Allow passing home_id to save an API call to /me

### DIFF
--- a/docs/cli/configuration.md
+++ b/docs/cli/configuration.md
@@ -14,6 +14,7 @@ The following environment variables are supported:
 
 * `TADO_CREDENTIALS_FILE` - Path to a file which holds your Tado credentials. Be careful: do not share this file with others.
 * `TADO_REFRESH_TOKEN` - Tado refresh token, from previous login. Valid for one-time use only.
+* `TADO_HOME_ID` - Tado Home ID. If not supplied, will be automatically retrieved via the API.
 
 !!! note
 

--- a/docs/cli/usage.md
+++ b/docs/cli/usage.md
@@ -27,6 +27,7 @@ Usage: tado [OPTIONS] COMMAND [ARGS]...
 Options:
     -f, --credentials-file TEXT   Full path to a file in which the Tado credentials will be stored and read from [optional]
     -t, --refresh-token TEXT      A Tado refresh token, retrieved from prior authentication with Tado [optional]
+    -i, --home-id TEXT            Your Tado Home ID, retrieved from prior use of 'Tado home' [optional]
     -h, --help                    Show this message and exit.
 
 Commands:

--- a/docs/getting-started/usage.md
+++ b/docs/getting-started/usage.md
@@ -33,3 +33,36 @@ else:
 ```
 
 Check out `all available API methods <api>` to learn what you can to with libtado.
+
+## Optional: Saving on API requests by specifying your Home ID
+
+Each Tado account has a Home, which by itself has a unique ID. 
+This number is needed to retrieve any details from your heating system.
+It should never change, unless moving and setting up a new system on your account.
+
+By default, libtado makes a request to the `/me` API to retrieve it. 
+Up until September 2025, this was the preferred method, as the API had unlimited use, 
+and this made it very easy to get started. 
+But with the strict rate limits which Tado now has introduced, this can lead to unnecessary API calls.
+
+If creating `tado.api()` objects often, such as in the CLI or commandline scripts,
+you can avoid making this API call every time by retrieving your `home_id` once,
+ then specifying it in the constructor of `libtado.api`:
+
+```python
+from libtado.api import Tado
+
+t = Tado(token_file_path='/path/to/a/secure/folder/tado-credentials.json')
+tado_home_id = t.get_home_id()
+# store the value of tado_home_id somewhere, such as in a file, or hard-code it in your script.
+```
+
+In successive calls, pass home_id to `tado.api()`:
+
+```python
+from libtado.api import Tado
+tado_home_id = 1234567 # previously returned value of t.get_home_id()
+t = Tado(token_file_path='/path/to/a/secure/folder/tado-credentials.json', home_id=tado_home_id)
+```
+
+The library should now use this as your Home ID and not call the `/me` API to get it.

--- a/libtado/__main__.py
+++ b/libtado/__main__.py
@@ -14,8 +14,9 @@ CONTEXT_SETTINGS = dict(help_option_names=['-h', '--help'])
 @click.group(context_settings=CONTEXT_SETTINGS)
 @click.option('--refresh-token', '-t', required=False, envvar='TADO_REFRESH_TOKEN', cls=MutuallyExclusiveOption, help='A Tado refresh token, retrieved from prior authentication with Tado', mutually_exclusive=["credentials_file"])
 @click.option('--credentials-file', '-f', required=False, envvar='TADO_CREDENTIALS_FILE', cls=MutuallyExclusiveOption, help='Full path to a file in which the Tado credentials will be stored and read from', mutually_exclusive=["refresh_token"])
+@click.option('--home-id', '-i', required=False, envvar='TADO_HOME_ID', help='The ID of your Tado Home, which you can retrieve using the \'tado home\' command. (optional)')
 @click.pass_context
-def main(ctx, refresh_token, credentials_file):
+def main(ctx, refresh_token, credentials_file, home_id):
   """
   Example
   =======
@@ -32,8 +33,8 @@ def main(ctx, refresh_token, credentials_file):
 
   Call 'tado COMMAND --help' to see available options for subcommands.
   """
-
-  ctx.obj = libtado.api.Tado(refresh_token, credentials_file)
+  home_id_parsed = int(home_id) if home_id is not None else None
+  ctx.obj = libtado.api.Tado(refresh_token, credentials_file, home_id_parsed)
   status = ctx.obj.get_device_activation_status()
   if status == "PENDING":
       ctx.obj.device_activation()

--- a/libtado/api.py
+++ b/libtado/api.py
@@ -7,7 +7,13 @@ your smart thermostats.
 
 Example:
   import libtado.api
-  t = tado.api('Username', 'Password', 'ClientSecret')
+  t = tado.api(token_file_path='/path/to/my/tado-credentials.json')
+  auth_status = t.get_device_activation_status()
+
+  if auth_status == "PENDING":
+    print('Copy and paste the following URL in your web browser to log in: ', t.get_device_verification_url())
+    t.device_activation()
+
   print(t.get_me())
 
 Disclaimer:
@@ -140,8 +146,9 @@ class Tado:
   timeout                  = 15
   user_code                = None
 
-  def __init__(self, saved_refresh_token: str = None, token_file_path: str = None):
+  def __init__(self, saved_refresh_token: str = None, token_file_path: str = None, home_id: int = None):
     self.token_file_path = token_file_path
+    self.id = home_id
 
     if (saved_refresh_token or self.load_token()) and self.refresh_auth(
             refresh_token=saved_refresh_token, force_refresh=True
@@ -304,7 +311,8 @@ class Tado:
     self.device_ready()
 
   def device_ready(self):
-    self.id = self.get_me()['homes'][0]['id']
+    if self.id is None:
+      self.id = self.get_home_id()
     self.user_code = None
     self.device_verification_url = None
     self.device_activation_status = DeviceActivationStatus.COMPLETED
@@ -1028,6 +1036,21 @@ class Tado:
     """
     data = self._api_call('homes/%i/mobileDevices' % self.id)
     return data
+
+  def get_home_id(self):
+    """
+    Gets the ID of your Tado Home. You can optionally set this as the `home_id` parameter when constructing a new
+    instance of `libtado.api.Tado` to reduce API calls.
+
+    Returns:
+      (int): The ID of the home of the current user.
+
+    ??? info "Result example"
+        ```text
+        1234567
+        ```
+    """
+    return self.get_me()['homes'][0]['id']
 
   def get_schedule_timetables(self, zone):
     """

--- a/tests/api/test_api.py
+++ b/tests/api/test_api.py
@@ -44,6 +44,11 @@ class TestApi:
 
         assert isinstance(response, dict)
 
+    def test_get_home_id(self):
+        response = tado.get_home_id()
+
+        assert isinstance(response, int)
+
     def get_installations(self):
         response = tado.get_home()
 


### PR DESCRIPTION
In order to reduce calls to the Tado API, allow manually passing of `home_id` to avoid a call to `/me` to retrieve it.

You can get `home_id` with the new method `t.get_home_id()` or using the CLI via the existing `tado homes` command.

The `home_id` can also be passed as `-i` or `--home-id` to the CLI.